### PR TITLE
Users API: Fixed sending invite when using form requests

### DIFF
--- a/app/Users/Controllers/UserApiController.php
+++ b/app/Users/Controllers/UserApiController.php
@@ -90,7 +90,7 @@ class UserApiController extends ApiController
     public function create(Request $request)
     {
         $data = $this->validate($request, $this->rules()['create']);
-        $sendInvite = ($data['send_invite'] ?? false) === true;
+        $sendInvite = boolval($data['send_invite'] ?? false) === true;
 
         $user = null;
         DB::transaction(function () use ($data, $sendInvite, &$user) {

--- a/resources/views/api-docs/parts/getting-started.blade.php
+++ b/resources/views/api-docs/parts/getting-started.blade.php
@@ -67,6 +67,12 @@
 </p>
 
 <p>
+    <em>
+        * Form requests can accept boolean (<code>true</code>/<code>false</code>) values via a <code>1</code> or <code>0</code>.
+    </em>
+</p>
+
+<p>
     Regardless of format chosen, ensure you set a <code>Content-Type</code> header on requests so that the system can correctly parse your request data.
     The API is primarily designed to be interfaced using JSON, since responses are always in JSON format, hence examples in this documentation will be shown as JSON.
     Some endpoints, such as those that receive file data, may require the use of <code>multipart/form-data</code>. This will be mentioned within the description for such endpoints.
@@ -82,17 +88,19 @@
 
 <pre><code class="language-json">{
   "name": "My new item",
+  "locked": true,
   "books": [105, 263],
   "tags": [{"name": "Tag Name", "value": "Tag Value"}],
 }</code></pre>
 
 <p><strong>x-www-form-urlencoded</strong></p>
 
-<pre><code class="language-text">name=My%20new%20item&books%5B0%5D=105&books%5B1%5D=263&tags%5B0%5D%5Bname%5D=Tag%20Name&tags%5B0%5D%5Bvalue%5D=Tag%20Value</code></pre>
+<pre><code class="language-text">name=My%20new%20item&locked=1&books%5B0%5D=105&books%5B1%5D=263&tags%5B0%5D%5Bname%5D=Tag%20Name&tags%5B0%5D%5Bvalue%5D=Tag%20Value</code></pre>
 
 <p><strong>x-www-form-urlencoded (Decoded for readability)</strong></p>
 
 <pre><code class="language-text">name=My new item
+locked=1
 books[0]=105
 books[1]=263
 tags[0][name]=Tag Name

--- a/tests/Api/UsersApiTest.php
+++ b/tests/Api/UsersApiTest.php
@@ -143,6 +143,23 @@ class UsersApiTest extends TestCase
         Notification::assertSentTo($user, UserInviteNotification::class);
     }
 
+    public function test_create_with_send_invite_works_with_value_of_1()
+    {
+        $this->actingAsApiAdmin();
+        Notification::fake();
+
+        $resp = $this->postJson($this->baseEndpoint, [
+            'name'        => 'Benny Boris',
+            'email'       => 'bboris@example.com',
+            'send_invite' => '1', // Submissions via x-www-form-urlencoded/form-data may use 1 instead of boolean
+        ]);
+
+        $resp->assertStatus(200);
+        /** @var User $user */
+        $user = User::query()->where('email', '=', 'bboris@example.com')->first();
+        Notification::assertSentTo($user, UserInviteNotification::class);
+    }
+
     public function test_create_name_and_email_validation()
     {
         $this->actingAsApiAdmin();


### PR DESCRIPTION
- Cast send_invite value in cases where it might not have been a boolean, which occurs on non-JSON requests.
- Added test to cover.
- Updated API docs to mention and shown boolean usage.